### PR TITLE
fix(Api): Appsettings ConnectionString was wrong

### DIFF
--- a/src/CRUD.Api/appsettings.json
+++ b/src/CRUD.Api/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "ConnectionStrings": {"ServerConnection":"Data source=WINAP0WHKTBVUQ6\\SQLEXPRESS;Initial Catalog=DesafioInternalTalent;Integrated Security=true"},
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
This is part of a series of fixes due to some Git Conflicts.
This fixes the setting for ConnectionString on appsettings.json